### PR TITLE
Clarify documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,38 +12,41 @@ I have recently made it harder to break the application by fixing bugs. If you f
 
 ## Directions
 
+1. [Install `yt-dlp`](https://github.com/yt-dlp/yt-dlp#installation)
+2. Clone this repo and make the script executable
+   ```sh
+   git clone https://github.com/exadisme/auto-ytdlp.git
+   cd auto-ytdlp
+   chmod +x auto-ytdlp
+   ```
 
-This script requires yt-dlp you can install for your distro or get it here: https://github.com/yt-dlp/yt-dlp
+Place the files somewhere within your path or add the folder to your path variable. All files need to be together for this to work.
 
+Once installed, you can use the `auto-ytdlp -a <URL> <SaveDirectory> <Name of the channel>` command to add channels or playlists to check for videos.
 
-```git clone https://github.com/exadisme/auto-ytdlp.git```
+Running `auto-ytdlp` after adding channels or playlists will download videos found in those channels or playlists that fall within the configured time range.
 
-```cd auto-ytdlp```
-
-Make it executable: ```chmod +x auto-ytdlp```
-
-Place files somewhere within your path or add the folder to your path variable. All files need to be together for this to work.
-
+See the `--help` output for more options:
 
 ```
 Usage:
-     auto-ytdlp                                 Will check for youtube video updates and download them.
+     auto-ytdlp                                       Will check for youtube video updates and download them.
      auto-ytdlp [options]
 
 Options:
-     --help                                     Shows this menu.
-     -l                                         List all currently added channels.
-     -a URL SaveDirectory Name of the channel   Add a channel or playlist.
-     -d <number>                                Delete a channel. Get the number from list.
-     -u <number>                                Change how far back, in days, the script looks for new videos. Default is 5 days back.
-     -p <number>                                Change how many videos in the playlist yt-dlp will check the dates of. Higher value can increase the time it takes to fetch videos, Lower values may cause you to miss videos if content is uploaded often. Default is 10.
+     --help                                           Shows this menu.
+     -l                                               List all currently added channels.
+     -a <URL> <SaveDirectory> <Name of the channel>   Add a channel or playlist.
+     -d <number>                                      Delete a channel. Get the number from list.
+     -u <number>                                      Change how far back, in days, the script looks for new videos. Default is 5 days back.
+     -p <number>                                      Change how many videos in the playlist yt-dlp will check the dates of. Higher value can increase the time it takes to fetch videos, Lower values may cause you to miss videos if content is uploaded often. Default is 10.
 ```
 
 ## Running as a service systemd
 
 If you wanted to set this up as a service you could create a systemd service with the following options:
 
-```
+```conf
 [Unit]
 Description=Youtube video downloader script
 Wants=network-online.target
@@ -59,8 +62,10 @@ Environment="DISPLAY=:0" "XAUTHORITY=/home/<your username>/.Xauthority"
 [Install]
 WantedBy=multi-user.target
 ```
+
 If you wanted it to run every 2 hours or so, you could also set up a .timer for the service like so:
-```
+
+```conf
 [Unit]
 Description=Run my youtube download script every 2 hours.
 
@@ -72,4 +77,15 @@ Unit=youtube_download.service
 [Install]
 WantedBy=multi-user.target
 ```
-then you could ```sudo systemctl enable youtube_download.service --now```
+
+then you can run
+
+```sh
+sudo systemctl enable youtube_download.service --now
+```
+
+to run the system service on the specified timer interval.
+
+## `notify-send` optional dependency
+
+This script will attempt to use `notify-send` but will not fail if it is missing. If your system does not have `notify-send` installed you can ignore the warning or install it.

--- a/auto-ytdlp
+++ b/auto-ytdlp
@@ -41,16 +41,16 @@ dir_size_diff=(
 # Funtion that displays the help menu.
 function helpmenu() {
    echo Usage: 
-   echo "    " "auto-ytdlp""                                 Will check for youtube video updates and download them."
+   echo "    " "auto-ytdlp""                                       Will check for youtube video updates and download them."
    echo "    " "auto-ytdlp [options]"
    echo ""
    echo "Options:"
-   echo "    " "--help""                                     Shows this menu."
-   echo "    " "-l""                                         List all currently added channels."
-   echo "    " "-a URL SaveDirectory Name of the channel""   Add a channel or playlist."
-   echo "    " "-d <number>""                                Delete a channel. Get the number from list."
-   echo "    " "-u <number>""                                Change how far back, in days, the script looks for new videos. Default is 5 days back."
-   echo "    " "-p <number>""                                Change how many videos in the playlist yt-dlp will check the dates of. Higher value can increase the time it takes to fetch videos, Lower values may cause you to miss videos if content is uploaded often. Default is 10."
+   echo "    " "--help""                                           Shows this menu."
+   echo "    " "-l""                                               List all currently added channels."
+   echo "    " "-a <URL> <SaveDirectory> <Name of the channel>""   Add a channel or playlist."
+   echo "    " "-d <number>""                                      Delete a channel. Get the number from list."
+   echo "    " "-u <number>""                                      Change how far back, in days, the script looks for new videos. Default is 5 days back."
+   echo "    " "-p <number>""                                      Change how many videos in the playlist yt-dlp will check the dates of. Higher value can increase the time it takes to fetch videos, Lower values may cause you to miss videos if content is uploaded often. Default is 10."
 exit
 }
 
@@ -74,15 +74,15 @@ function check_num {
 function add_channel() {
    if [ -z $first ]; then
       echo "Error: a URL is required"
-      echo "Usage: auto-ytdlp -a URL SaveDirectory Name of the channel"
+      echo "Usage: auto-ytdlp -a <URL> <SaveDirectory> <Name of the channel>"
       exit
    elif [ -z $second ]; then
       echo "Error: a directory is required"
-      echo "Usage: auto-ytdlp -a URL SaveDirectory Name of the channel"
+      echo "Usage: auto-ytdlp -a <URL> <SaveDirectory> <Name of the channel>"
       exit
       elif [[ -z "${third%% *}" ]]; then
       echo "Error: a name is required"
-      echo "Usage: auto-ytdlp -a URL SaveDirectory Name of the channel"
+      echo "Usage: auto-ytdlp -a <URL> <SaveDirectory> <Name of the channel>"
       exit
    fi
    for channel in "${channels[@]}"; do


### PR DESCRIPTION
Hey, thanks for releasing this utility, I like it!

This is just a quick PR trying to help clarify a few spots in the documentation and `--help` output where I ran into issues/confusion while setting it up on my machine.

- Clarify `-a` flag option requirements
- Clarify installation instructions
- Call out `notify-send` which may not be available but shouldn't break the script (At least it didn't break for me on Pop!_OS which doesn't have `notify-send` preinstalled)
- Add codefence language flags for pretty code block rendering in GitHub :sparkles:
- Clean up markdown while I'm at it because it bugs me slightly and I can't help myself :laughing: